### PR TITLE
Rebind right-hand player keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Rust and Bevy on your particular platform better than I could.
 
 The game has two players starting in the bottom left and right. To control the
 left player use W, A, S, D to move. Q rotates counter clockwise and E rotates
-clockwise. The corresponding keys for the right player are ↑, ←, ↓, →, ?, and
-Shift.
+clockwise. The corresponding keys for the right player are I, J, K, L, U, and
+O.
 
 The game ends when the two players roughly tile the target. Five seconds later
 the game restarts.

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,12 +251,12 @@ const PLAYER_KEYS: [Keys; 2] = [
         rot_cw: KeyCode::E,
     },
     Keys {
-        up: KeyCode::Up,
-        left: KeyCode::Left,
-        down: KeyCode::Down,
-        right: KeyCode::Right,
-        rot_ccw: KeyCode::Slash,
-        rot_cw: KeyCode::RShift,
+        up: KeyCode::I,
+        left: KeyCode::J,
+        down: KeyCode::K,
+        right: KeyCode::L,
+        rot_ccw: KeyCode::U,
+        rot_cw: KeyCode::O,
     },
 ];
 fn move_players(


### PR DESCRIPTION
**This Commit**
Uses I, J, K, L, U, and O for the right hand player movement instead of
the arrow keys.

**Why?**
Well it's slightly more vim-like so that's cool but the real reason is
that it's more symmetric and works on keyboards who might not have arrow
keys near their Shift + ? keys.

Co-authored-by: Brian Smith <smithbrian387@gmail.com>