### PR TITLE
Split players/targets into files

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,130 @@
+use super::{utils, SIZE, TIME_STEP};
+
+use bevy::prelude::*;
+use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
+
+const PLAYER_SPEEDS: [f32; 2] = [200.0, 240.0];
+const ROT_SPEEDS: [f32; 2] = [1.0, 0.6];
+
+#[derive(Component)]
+pub struct Player {
+    idx: usize,
+    points: Vec<[f32; 3]>,
+}
+
+pub fn spawn_players(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // HACK
+    let level1 = utils::generate_levels().pop().unwrap();
+    let player1_points = utils::mesh_points_raw(&level1.player1).unwrap().clone();
+    commands
+        .spawn_bundle(MaterialMesh2dBundle {
+            mesh: Mesh2dHandle(meshes.add(level1.player1)),
+            transform: Transform::default()
+                .with_scale(SIZE)
+                .with_translation([-50.0, -100.0, 0.0].into()),
+            material: materials.add(ColorMaterial::default()),
+            ..default()
+        })
+        .insert(Player {
+            idx: 0,
+            points: player1_points,
+        });
+    let player2_points = utils::mesh_points_raw(&level1.player2).unwrap().clone();
+    commands
+        .spawn_bundle(MaterialMesh2dBundle {
+            mesh: Mesh2dHandle(meshes.add(level1.player2)),
+            transform: Transform::default()
+                .with_scale(SIZE)
+                .with_translation([50.0, -100.0, 0.0].into()),
+            material: materials.add(ColorMaterial::default()),
+            ..default()
+        })
+        .insert(Player {
+            idx: 1,
+            points: player2_points,
+        });
+}
+
+// TODO show keys in a legend on the sides of the game.
+struct Keys {
+    up: KeyCode,
+    left: KeyCode,
+    down: KeyCode,
+    right: KeyCode,
+    rot_cw: KeyCode,
+    rot_ccw: KeyCode,
+}
+const PLAYER_KEYS: [Keys; 2] = [
+    Keys {
+        up: KeyCode::W,
+        left: KeyCode::A,
+        down: KeyCode::S,
+        right: KeyCode::D,
+        rot_ccw: KeyCode::Q,
+        rot_cw: KeyCode::E,
+    },
+    Keys {
+        up: KeyCode::I,
+        left: KeyCode::J,
+        down: KeyCode::K,
+        right: KeyCode::L,
+        rot_ccw: KeyCode::U,
+        rot_cw: KeyCode::O,
+    },
+];
+pub fn move_players(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut query: Query<(&mut Transform, &Player)>,
+) {
+    for (mut transform, player) in query.iter_mut() {
+        let Keys {
+            up,
+            left,
+            down,
+            right,
+            rot_cw,
+            rot_ccw,
+        } = PLAYER_KEYS[player.idx];
+
+        // TODO Test with conversion to i8 and doing ((l ^ r) + (l - r)) as f32
+        let left_pressed = keyboard_input.pressed(left);
+        let right_pressed = keyboard_input.pressed(right);
+        if left_pressed != right_pressed {
+            let x_direction = if left_pressed { -1.0 } else { 1.0 };
+            let old_x = transform.translation.x;
+            transform.translation.x += x_direction * PLAYER_SPEEDS[player.idx] * TIME_STEP;
+
+            if utils::points_collide_with_wall(&player.points, &transform) != 0 {
+                transform.translation.x = old_x;
+            }
+        }
+        let down_pressed = keyboard_input.pressed(down);
+        let up_pressed = keyboard_input.pressed(up);
+        if down_pressed != up_pressed {
+            let y_direction = if down_pressed { -1.0 } else { 1.0 };
+            let old_y = transform.translation.y;
+            transform.translation.y += y_direction * PLAYER_SPEEDS[player.idx] * TIME_STEP;
+
+            if utils::points_collide_with_wall(&player.points, &transform) != 0 {
+                transform.translation.y = old_y;
+            }
+        }
+        let rot_ccw_pressed = keyboard_input.pressed(rot_ccw);
+        let rot_cw_pressed = keyboard_input.pressed(rot_cw);
+        if rot_ccw_pressed != rot_cw_pressed {
+            let rotation_direction = if rot_ccw_pressed { -1.0 } else { 1.0 };
+            let old_rotation = transform.rotation;
+            let rotate_by =
+                Quat::from_rotation_z(rotation_direction * ROT_SPEEDS[player.idx] * TIME_STEP);
+            transform.rotation = transform.rotation.mul_quat(rotate_by);
+
+            if utils::points_collide_with_wall(&player.points, &transform) != 0 {
+                transform.rotation = old_rotation;
+            }
+        }
+    }
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,100 @@
+use super::{utils, SIZE, TIME_STEP};
+
+use bevy::prelude::*;
+use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
+use rand::prelude::*;
+
+const INITIAL_TARGET_SPEED: f32 = 20.0;
+const MIN_TARGET_SPEED: f32 = 10.0;
+const MAX_TARGET_SPEED: f32 = 40.0;
+const TARGET_ROT_SPEED: f32 = 0.1;
+
+#[derive(Component)]
+pub struct Target {
+    points: Vec<[f32; 3]>,
+}
+#[derive(Clone, Copy, Component)]
+pub struct Velocity(Vec2);
+#[derive(Clone, Copy, Component)]
+pub struct Rotation(f32);
+
+pub fn spawn_target(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // HACK
+    let level_data = utils::generate_levels().pop().unwrap();
+    let target_points = utils::mesh_points_raw(&level_data.target).unwrap().clone();
+    commands
+        .spawn_bundle(MaterialMesh2dBundle {
+            mesh: Mesh2dHandle(meshes.add(level_data.target)),
+            transform: Transform::default()
+                .with_scale(SIZE)
+                .with_translation([0.0, 100.0, 0.0].into()),
+            material: materials.add(ColorMaterial::default()),
+            ..default()
+        })
+        .insert(Target {
+            points: target_points,
+        })
+        .insert(Rotation(TARGET_ROT_SPEED))
+        .insert(Velocity(
+            [INITIAL_TARGET_SPEED, INITIAL_TARGET_SPEED].into(),
+        ));
+}
+
+pub fn move_target(mut query: Query<(&mut Transform, &Target, &mut Velocity, &mut Rotation)>) {
+    let (mut transform, target, mut velocity, mut rotation) = query.single_mut();
+
+    // Check if moving would get us out of bounds.
+    let old_x = transform.translation.x;
+    let old_y = transform.translation.y;
+    transform.translation.x += velocity.0.x * TIME_STEP;
+    transform.translation.y += velocity.0.y * TIME_STEP;
+    let collision = utils::points_collide_with_wall(&target.points, &transform);
+
+    if collision & utils::WALL_COLLISION_HORIZONTAL > 0 {
+        transform.translation.x = old_x;
+        velocity.0.x *= -1.0;
+    }
+    if collision & utils::WALL_COLLISION_VERTICAL > 0 {
+        transform.translation.y = old_y;
+        velocity.0.y *= -1.0;
+    }
+
+    // Check if rotating would get us out of bounds.
+    let old_rotation = transform.rotation;
+    let rotate_by = Quat::from_rotation_z(rotation.0 * TIME_STEP);
+    transform.rotation = transform.rotation.mul_quat(rotate_by);
+    let collision = utils::points_collide_with_wall(&target.points, &transform);
+
+    if collision > 0 {
+        transform.rotation = old_rotation;
+        rotation.0 *= -1.0;
+    }
+
+    // TODO For deterministic mode, seed the RNG too.
+    *velocity = accelerate_target(*velocity);
+}
+
+fn accelerate_target(mut velocity: Velocity) -> Velocity {
+    // TODO generate fewer random numbers. Also, don't use a cryptographically secure RNG.
+    if thread_rng().gen_bool(0.1) {
+        velocity.0.x *= thread_rng().gen_range(0.5..2.0);
+        velocity.0.x = handle_target_velocity_overflow(velocity.0.x);
+        velocity.0.y *= thread_rng().gen_range(0.5..2.0);
+        velocity.0.y = handle_target_velocity_overflow(velocity.0.y);
+    }
+
+    velocity
+}
+
+/// If the target is going too slowly or too quickly just set it back to the initial speed.
+fn handle_target_velocity_overflow(speed: f32) -> f32 {
+    if !(MIN_TARGET_SPEED..MAX_TARGET_SPEED).contains(&speed.abs()) {
+        INITIAL_TARGET_SPEED * speed.signum()
+    } else {
+        speed
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,35 @@
 use bevy::prelude::*;
 use bevy::render::mesh::PrimitiveTopology;
+use bevy::render::mesh::VertexAttributeValues;
 
+use super::{HALF_SCREEN_HEIGHT, HALF_SCREEN_WIDTH};
+
+pub const WALL_COLLISION_NONE: u8 = 0;
+pub const WALL_COLLISION_HORIZONTAL: u8 = 1;
+pub const WALL_COLLISION_VERTICAL: u8 = 2;
+
+pub fn mesh_points_raw(mesh: &Mesh) -> Option<&Vec<[f32; 3]>> {
+    mesh.attribute(Mesh::ATTRIBUTE_POSITION)
+        .map(|position| match position {
+            // TODO first and last points are probably always the same - can probably skip first.
+            VertexAttributeValues::Float32x3(points) => points,
+            _ => unreachable!(),
+        })
+}
+pub fn points_collide_with_wall(points: &[[f32; 3]], transform: &Transform) -> u8 {
+    let mut collision = WALL_COLLISION_NONE;
+    for point in points {
+        let point = transform.mul_vec3(Vec3::from(*point));
+        if point.x <= -HALF_SCREEN_WIDTH || point.x >= HALF_SCREEN_WIDTH {
+            collision |= WALL_COLLISION_HORIZONTAL;
+        } else if point.y <= -HALF_SCREEN_HEIGHT || point.y >= HALF_SCREEN_HEIGHT {
+            collision |= WALL_COLLISION_VERTICAL;
+        }
+    }
+    collision
+}
+
+// TODO Move this to files or something?
 pub struct LevelData {
     /// Target shape to tile onto.
     pub target: Mesh,


### PR DESCRIPTION
**This Commit**
Started as an attempt to pull out some plugins but I didn't know how to
do that with system sets. Instead I just settled for extracting some
stuff into some modules.

**Why?**
Maybe it's easier to read. I'm not really sure. Probably a mistake I'll
regret later. I know the keys stuff will have to come out at some point
since we'll want legends on the UI when I figure that out. The utils
module is also a mess, of course, but that'll probably need to wait
until I understand how to do levels.